### PR TITLE
Use <C-t>[hjkl] to move cursor between windows

### DIFF
--- a/config/.tmux.conf
+++ b/config/.tmux.conf
@@ -81,23 +81,6 @@ set -sg escape-time 1
 # 設定ファイルをリロードする
 bind r source-file ~/.tmux.conf \; display "Reloaded!"
 
-# Vim Tmux Navigator
-# See: https://github.com/christoomey/vim-tmux-navigator
-bind -n C-w switch-client -T NAVIGATOR
-
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-bind -T NAVIGATOR h if-shell "$is_vim" "send-keys C-w h"  "select-pane -L"
-bind -T NAVIGATOR j if-shell "$is_vim" "send-keys C-w j"  "select-pane -D"
-bind -T NAVIGATOR k if-shell "$is_vim" "send-keys C-w k"  "select-pane -U"
-bind -T NAVIGATOR l if-shell "$is_vim" "send-keys C-w l"  "select-pane -R"
-bind -T NAVIGATOR \ if-shell "$is_vim" "send-keys C-w \\" "select-pane -l"
-bind -T copy-mode-vi C-h select-pane -L
-bind -T copy-mode-vi C-j select-pane -D
-bind -T copy-mode-vi C-k select-pane -U
-bind -T copy-mode-vi C-l select-pane -R
-bind -T copy-mode-vi C-\ select-pane -l
-
 # ================================================
 # mouse
 # ================================================
@@ -127,3 +110,21 @@ set -g @continuum-boot-options 'iterm,fullscreen'
 
 run-shell '~/.tmux/plugins/tpm/tpm'
 
+
+# ================================================
+# Vim Tmux Navigator
+# ================================================
+
+# See: https://github.com/christoomey/vim-tmux-navigator
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+bind h if-shell "$is_vim" "send-keys C-w h"  "select-pane -L"
+bind j if-shell "$is_vim" "send-keys C-w j"  "select-pane -D"
+bind k if-shell "$is_vim" "send-keys C-w k"  "select-pane -U"
+bind l if-shell "$is_vim" "send-keys C-w l"  "select-pane -R"
+bind \ if-shell "$is_vim" "send-keys C-w \\" "select-pane -l"
+bind -T copy-mode-vi C-h select-pane -L
+bind -T copy-mode-vi C-j select-pane -D
+bind -T copy-mode-vi C-k select-pane -U
+bind -T copy-mode-vi C-l select-pane -R
+bind -T copy-mode-vi C-\ select-pane -l


### PR DESCRIPTION
## WHY
currently, my tmux catches all <kbd>C-w</kbd> operations.
so i cannot use it on vim, e.g. <kbd>C-w</kbd> + <kbd>=</kbd>

## WHAT
Use <kbd>C-t</kbd>(tmux's prefix key) to move cursor between windows/panes