### PR TITLE
Stop tapping caskroom/versions and add docker as formula

### DIFF
--- a/cookbooks/docker/default.rb
+++ b/cookbooks/docker/default.rb
@@ -1,5 +1,5 @@
 if node[:platform] == 'darwin'
-  brew_tap 'caskroom/versions'
+  package 'docker'
   cask 'docker'
   cask 'docker-toolbox'
 end


### PR DESCRIPTION
## Why

## What

