### PR TITLE
Add add-obsidian-task skill for Claude Code

### DIFF
--- a/config/.claude/skills/add-obsidian-task/SKILL.md
+++ b/config/.claude/skills/add-obsidian-task/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: add-obsidian-task
+description: Use when the user wants to add a task, create a new task, or record work to do in Obsidian. Triggers on phrases like "タスクを追加", "タスクを作成", "タスクを登録", "add a task", "create a task", or any request to record a new task item.
+---
+
+# Add Obsidian Task
+
+Add a new task note to Obsidian with project/context tags and metadata via `obsidian` CLI.
+
+## Available Projects and Contexts
+
+### Projects
+!`obsidian tags | grep "^#task/pj/" | sed 's|#task/pj/||'`
+
+### Contexts
+!`obsidian tags | grep "^#task/ctx/" | sed 's|#task/ctx/||'`
+
+## Workflow
+
+### 1. Determine Title and Body
+
+Generate from user input:
+
+- **Title**: Concise, action-oriented. Must not contain `/\:*?"<>|`.
+- **Body**: Detailed description, acceptance criteria, notes in markdown.
+
+If the user already provided a clear title, use it directly after sanitizing.
+
+### 2. Prioritize Tag Candidates
+
+Sort the pre-loaded project and context lists by relevance:
+
+- Current working directory name / git repo name
+- Task content keywords
+- Place most relevant options first (top 4)
+
+### 3. Ask User
+
+Use `AskUserQuestion` with three questions in a single call:
+
+- **Context** (`ctx`): Top 4 relevant contexts from the list above
+- **Project** (`pj`): Top 4 relevant projects from the list above
+- **Status**: `icebox` / `planned` / `in-progress`
+  - `icebox` — idea captured, no active plan
+  - `planned` — scheduled, sets `task_review_date` = today + 7 days
+  - `in-progress` — actively working on now
+
+### 4. Execute Script
+
+Run `scripts/add-task.sh` with positional arguments:
+
+```bash
+bash "${SKILL_DIR}/scripts/add-task.sh" '<title>' '<project>' '<context>' '<status>' '<content>'
+```
+
+The script:
+1. Creates the note via `obsidian unique`
+2. Sets `tags` property with `#task/ctx/…`, `#task/pj/…`, `#task/status/…`
+3. If `planned`, sets `task_review_date` to 7 days from today
+4. Prints the created file path
+
+### 5. Report
+
+Show the created file path and confirm applied tags. If `planned`, confirm `task_review_date`.

--- a/config/.claude/skills/add-obsidian-task/SKILL.md
+++ b/config/.claude/skills/add-obsidian-task/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: add-obsidian-task
 description: Use when the user wants to add a task, create a new task, or record work to do in Obsidian. Triggers on phrases like "タスクを追加", "タスクを作成", "タスクを登録", "add a task", "create a task", or any request to record a new task item.
+allowed-tools: Bash(~/.claude/skills/add-obsidian-task/scripts/*)
 ---
 
 # Add Obsidian Task

--- a/config/.claude/skills/add-obsidian-task/SKILL.md
+++ b/config/.claude/skills/add-obsidian-task/SKILL.md
@@ -10,10 +10,10 @@ Add a new task note to Obsidian with project/context tags and metadata via `obsi
 ## Available Projects and Contexts
 
 ### Projects
-!`obsidian tags | grep "^#task/pj/" | sed 's|#task/pj/||'`
+!`${SKILL_DIR}/scripts/list-projects.sh`
 
 ### Contexts
-!`obsidian tags | grep "^#task/ctx/" | sed 's|#task/ctx/||'`
+!`${SKILL_DIR}/scripts/list-contexts.sh`
 
 ## Workflow
 

--- a/config/.claude/skills/add-obsidian-task/SKILL.md
+++ b/config/.claude/skills/add-obsidian-task/SKILL.md
@@ -10,10 +10,10 @@ Add a new task note to Obsidian with project/context tags and metadata via `obsi
 ## Available Projects and Contexts
 
 ### Projects
-!`${SKILL_DIR}/scripts/list-projects.sh`
+!`~/.claude/skills/add-obsidian-task/scripts/list-projects.sh`
 
 ### Contexts
-!`${SKILL_DIR}/scripts/list-contexts.sh`
+!`~/.claude/skills/add-obsidian-task/scripts/list-contexts.sh`
 
 ## Workflow
 
@@ -50,7 +50,7 @@ Use `AskUserQuestion` with three questions in a single call:
 Run `scripts/add-task.sh` with positional arguments:
 
 ```bash
-bash "${SKILL_DIR}/scripts/add-task.sh" '<title>' '<project>' '<context>' '<status>' '<content>'
+bash ~/.claude/skills/add-obsidian-task/scripts/add-task.sh '<title>' '<project>' '<context>' '<status>' '<content>'
 ```
 
 The script:

--- a/config/.claude/skills/add-obsidian-task/scripts/add-task.sh
+++ b/config/.claude/skills/add-obsidian-task/scripts/add-task.sh
@@ -35,7 +35,7 @@ new_tags_json=$(obsidian properties file="${file}" format=json |
 obsidian property:set name="tags" type="list" value="${new_tags_json}" file="${file}"
 
 if [ "${status}" = "planned" ]; then
-  review_date=$(date -v+7d +%Y-%m-%d)
+  review_date=$(date -d '+7 days' +%Y-%m-%d)
   obsidian property:set name="task_review_date" type="date" value="${review_date}" file="${file}"
 fi
 

--- a/config/.claude/skills/add-obsidian-task/scripts/add-task.sh
+++ b/config/.claude/skills/add-obsidian-task/scripts/add-task.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: add-task.sh <title> <project> <context> <status> <content>
+#   title   : Task title (must not contain /\:*?"<>|)
+#   project : Project slug (e.g. dotfiles)
+#   context : Context slug (e.g. work)
+#   status  : One of: icebox, planned, in-progress
+#   content : Markdown body of the task note
+
+title="$1"
+project="$2"
+context="$3"
+status="$4"
+content="$5"
+
+file=$(obsidian unique name="tasks/${project} - ${title}" content="${content}")
+
+existing_tags=$(obsidian tags file="${file}" 2>/dev/null || echo "")
+if [ -n "${existing_tags}" ]; then
+    new_tags="${existing_tags} #task/ctx/${context} #task/pj/${project} #task/status/${status}"
+else
+    new_tags="#task/ctx/${context} #task/pj/${project} #task/status/${status}"
+fi
+obsidian property:set name="tags" type="list" value="${new_tags}" file="${file}"
+
+if [ "${status}" = "planned" ]; then
+    review_date=$(date -v+7d +%Y-%m-%d)
+    obsidian property:set name="task_review_date" type="date" value="${review_date}" file="${file}"
+fi
+
+echo "${file}"

--- a/config/.claude/skills/add-obsidian-task/scripts/list-contexts.sh
+++ b/config/.claude/skills/add-obsidian-task/scripts/list-contexts.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+obsidian tags | grep "^#task/ctx/" | sed 's|#task/ctx/||'

--- a/config/.claude/skills/add-obsidian-task/scripts/list-projects.sh
+++ b/config/.claude/skills/add-obsidian-task/scripts/list-projects.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+obsidian tags | grep "^#task/pj/" | sed 's|#task/pj/||'


### PR DESCRIPTION
## Summary

- Add a user-level Claude Code skill (`~/.claude/skills/add-obsidian-task/`) for creating Obsidian task notes
- `SKILL.md` uses `!` commands to pre-embed available project/context tags at skill load time
- `scripts/add-task.sh` handles deterministic note creation, tag assignment, and `task_review_date` for planned tasks

## Details

The skill workflow:
1. Generates title and body from user input
2. Prioritizes project/context candidates based on current directory and task content
3. Asks user to select context, project, and status via `AskUserQuestion`
4. Executes `add-task.sh` which creates the note via `obsidian unique`, sets tags, and optionally sets review date

## Test plan

- [ ] Verify skill appears in Claude Code skill list
- [ ] Trigger with "タスクを追加して" and confirm workflow runs
- [ ] Confirm `planned` status sets `task_review_date` to today + 7 days
- [ ] Confirm `icebox` / `in-progress` do not set `task_review_date`

🤖 Generated with [Claude Code](https://claude.com/claude-code)