### PR TITLE
fix: launch jankyborders from aerospace instead of nix-darwin service

### DIFF
--- a/bin/deploy-config-files
+++ b/bin/deploy-config-files
@@ -67,6 +67,9 @@ mkdir -p ~/.config
 # aerospace
 ./bin/ln-idempotently ./config/.config/aerospace ~/.config/aerospace
 
+# jankyborders
+./bin/ln-idempotently ./config/.config/borders ~/.config/borders
+
 # hammerspoon
 ./bin/ln-idempotently ./config/.hammerspoon ~/.hammerspoon
 

--- a/config/.config/aerospace/aerospace.toml
+++ b/config/.config/aerospace/aerospace.toml
@@ -3,6 +3,7 @@
 after-startup-command = [
   # JankyBorders has a built-in detection of already running process,
   # so it won't be run twice on AeroSpace restart
+  'exec-and-forget $HOME/.nix-profile/bin/borders'
 ]
 
 # Start AeroSpace at login

--- a/config/.config/borders/bordersrc
+++ b/config/.config/borders/bordersrc
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+options=(
+	width=8.0
+	hidpi=on
+	active_color="gradient(top_right=0xfff4b8e4,bottom_left=0xff85c1dc)"
+	inactive_color=0x00000000
+	order=above
+)
+
+borders "${options[@]}"

--- a/config/.config/borders/bordersrc
+++ b/config/.config/borders/bordersrc
@@ -8,4 +8,4 @@ options=(
 	order=above
 )
 
-borders "${options[@]}"
+"$HOME/.nix-profile/bin/borders" "${options[@]}"

--- a/darwin-configuration.nix
+++ b/darwin-configuration.nix
@@ -93,14 +93,5 @@
   };
 
   services.tailscale.enable = true;
-  services.jankyborders = {
-    enable = true;
-    hidpi = true;
-    width = 8.0;
-    active_color = "gradient(top_right=0xfff4b8e4,bottom_left=0xff85c1dc)";
-    inactive_color = "0x00000000";
-    order = "above";
-  };
-
   nix.enable = false;
 }


### PR DESCRIPTION
## Summary
- nix-darwin の `services.jankyborders` LaunchAgent は OS 再起動時に Nix Store ボリュームがマウントされる前に起動し、`Missing executable detected` で失敗していた
- AeroSpace の `after-startup-command` から `borders` を起動するよう変更（GUI セッション確立後に実行されるため確実に動作する）
- 設定を `~/.config/borders/bordersrc` に分離し、`bin/deploy-config-files` で symlink を管理

## Test plan
- [ ] `darwin-rebuild switch` で nix-darwin を再適用
- [ ] `bin/deploy-config-files` を実行し `~/.config/borders` の symlink を確認
- [ ] AeroSpace をリロードして borders が起動するか確認
- [ ] OS を再起動して borders が正しく起動するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)