### PR TITLE
fix: remove borders order=above and adjust styles for screenshot compatibility

### DIFF
--- a/config/.config/borders/bordersrc
+++ b/config/.config/borders/bordersrc
@@ -1,11 +1,10 @@
 #!/bin/bash
 
 options=(
-	width=8.0
-	hidpi=on
-	active_color="gradient(top_right=0xfff4b8e4,bottom_left=0xff85c1dc)"
-	inactive_color=0x00000000
-	order=above
+  width=12.0
+  hidpi=on
+  active_color="gradient(top_right=0xfff4b8e4,bottom_left=0xff85c1dc)"
+  inactive_color=0x00000000
 )
 
 "$HOME/.nix-profile/bin/borders" "${options[@]}"

--- a/config/.config/ghostty/config
+++ b/config/.config/ghostty/config
@@ -21,7 +21,7 @@ confirm-close-surface = true
 # macOS specific settings
 macos-option-as-alt = left
 macos-titlebar-style = hidden
-macos-window-shadow = false
+# macos-window-shadow = true
 
 # shell integration
 shell-integration-features = no-cursor


### PR DESCRIPTION
## Summary

- Remove `order=above` from JankyBorders config to fix window screenshot capture issues
- Remove explicit `macos-window-shadow = false` from Ghostty config so shadow behavior matches other apps
- Increase border width from 8 to 12 to keep borders visible behind window shadows

## Background

`order=above` in JankyBorders rendered borders on top of windows, which broke macOS screenshot capture. Removing it places borders behind windows, but this exposed an inconsistency: Ghostty had window shadows explicitly disabled while other apps had shadows enabled, causing borders to look different across apps.

To unify the appearance, the explicit shadow-disable setting was removed from Ghostty (defaulting to shadow enabled). Since borders now sit behind window shadows, the border width was increased from 8 to 12 to remain noticeable.

## Test plan

- [ ] Verify window screenshots capture correctly without border artifacts
- [ ] Confirm border appearance is consistent between Ghostty and other apps
- [ ] Check that borders are visible behind window shadows at the new width

🤖 Generated with [Claude Code](https://claude.com/claude-code)