### PR TITLE
fix(nvim): unpin vim-matchup version to fix Go treesitter query error

### DIFF
--- a/config/.config/nvim/lazy-lock.json
+++ b/config/.config/nvim/lazy-lock.json
@@ -63,7 +63,7 @@
   "undo-glow.nvim": { "branch": "main", "commit": "ac70916caa2f4e57419bb4c1a2e303cdb7bb57e2" },
   "vim-better-whitespace": { "branch": "master", "commit": "de99b55a6fe8c96a69f9376f16b1d5d627a56e81" },
   "vim-illuminate": { "branch": "master", "commit": "0d1e93684da00ab7c057410fecfc24f434698898" },
-  "vim-matchup": { "branch": "master", "commit": "ea01ae7b54ed82d01aac03b796905e5ea0e28f1e" },
+  "vim-matchup": { "branch": "master", "commit": "dccb2d12ef2a703d2f076b3cda36a3339449d1eb" },
   "vim-mdx-js": { "branch": "master", "commit": "17179d7f2a73172af5f9a8d65b01a3acf12ddd50" },
   "vim-repeat": { "branch": "master", "commit": "65846025c15494983dafe5e3b46c8f88ab2e9635" },
   "vimade": { "branch": "master", "commit": "266cb28a451448754eb8ae2a2a46d6ae526b33f8" },

--- a/config/.config/nvim/lua/plugins/treesitter.lua
+++ b/config/.config/nvim/lua/plugins/treesitter.lua
@@ -94,7 +94,6 @@ return {
   },
   {
     "andymass/vim-matchup",
-    version = "*",
     event = { "BufReadPre" },
     dependencies = { "nvim-treesitter" },
     config = function()


### PR DESCRIPTION
## Summary

- Remove `version = "*"` from vim-matchup plugin spec to track latest master instead of tagged releases
- Fixes `E5108: Lua: Query error at 21:3. Impossible pattern: (if_statement` error when opening Go files in Neovim

## Root cause

The Go treesitter parser updated its AST structure, adding a `statement_list` node between `block` and `if_statement`. This made vim-matchup v0.8.0's Go query pattern `(block (if_statement ...))` structurally impossible, triggering the error on every cursor movement in Go files.

The fix ([andymass/vim-matchup#411](https://github.com/andymass/vim-matchup/pull/411)) is merged to master but not yet included in a release.

## Test plan

- [x] Open a Go file in Neovim — no E5108 error
- [x] Verify `%` key matches `if`/`else if`/`else` blocks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)