### PR TITLE
docs(claude): restructure Git rules section

### DIFF
--- a/config/.claude/CLAUDE.md
+++ b/config/.claude/CLAUDE.md
@@ -53,10 +53,26 @@
 
 ## Git Rules
 
-- **Conventional commit**: `feat:`, `fix:`, `build:`, `chore:`, `ci:`, `docs:`, `refactor:`, `perf:`, `test:`
+### Workflow
+
 - **Never work directly on main branch** - Create pull requests for each feature/fix
 - Make small, frequent commits per logical unit of work
 - **History rewriting is prohibited**: Do not use `--amend`, `--force`, or any commands that alter commit history
+
+### Writing commit messages and PRs (applies to both)
+
+- **Conventional commit prefix**: `feat:`, `fix:`, `build:`, `chore:`, `ci:`, `docs:`, `refactor:`, `perf:`, `test:`
+- **Language**: Follow the rules and conventions of the repository
+- Prose must add what the diff / code does not convey. If a sentence only narrates what the artifact already shows, delete it.
+
+### Pull Request specifics
+
+- PR descriptions must include:
+    - `Why`: reason for the change.
+    - `What`: outline of the change plus the important / watch-out points. Do not exhaustively list every file or implementation detail — the diff already shows them.
+- Optional `Notes for reviewers` to highlight places where the code alone does not convey intent, areas that need especially careful review (e.g. complex logic, domain-critical changes), or follow-up work. Keep it brief.
+- Do not add a `Test plan` section.
+- If `Why` is unknown, ask the user before finalizing the PR description.
 
 ---
 


### PR DESCRIPTION
## Why

The `Git Rules` section mixed rules that apply to commit messages, PRs, or both, making it unclear which rule applies where. The `Notes for reviewers` description also gave misleading examples (e.g. generated files) that didn't reflect what reviewers actually need surfaced.

## What

- Split `Git Rules` into three subsections:
    - `Workflow`: branch handling, commit granularity, history rewriting
    - `Writing commit messages and PRs (applies to both)`: shared rules — conventional commit prefix, language, prose guideline
    - `Pull Request specifics`: PR description structure and other PR-only rules
- Add a language rule: commit messages and PR bodies follow the repository's conventions
- Rewrite the `Notes for reviewers` description to emphasize places where code alone doesn't convey intent, areas needing careful review (complex logic, domain-critical changes), or follow-up work