### PR TITLE
docs(claude): optimize CLAUDE.md for Opus 4.7

### DIFF
--- a/config/.claude/CLAUDE.md
+++ b/config/.claude/CLAUDE.md
@@ -1,98 +1,77 @@
-## Development Principles
+## Core Principles
 
-### Agent-First
-- Delegate complex work to specialized agents
-- Use Task tool with appropriate subagent_type
+### 1. Plan Before Execute
+- Enter Plan Mode for complex work and only start implementation after user approval
+- When requirements are ambiguous, clarify first with `AskUserQuestion`
+- Answer questions (especially those ending with `?`) before proposing or starting work
 
-### Parallel Execution
-- Execute independent tasks in parallel
-- Send multiple Task tool calls in a single message
+### 2. Agent-First & Parallel by Default
+- Consider specialized agents (`feature-dev`, `code-review`, `codex-rescue`, `pr-review-toolkit`, etc.) before writing things yourself
+- Run independent tool calls **in parallel within a single message**
+  - e.g. send `git status` and `git diff` as two Bash calls in the same message
+  - e.g. fire multiple Read / Explore calls at once when targets are independent
+- Serialize only when there is a real dependency between calls
 
-### Plan Before Execute
-- Use Plan Mode for complex operations
-- Understand the full picture and get user approval before implementation
-- Use AskUserQuestion tool to clarify requirements or confirm approach
+### 3. Test-Driven Development
+- Red → Green → Refactor (twada-style): write a failing test → commit → minimal implementation → refactor
+- Use real databases in tests. Mocks are reserved for unavoidable cases such as external APIs
 
-### Test-Driven Development
-- Write tests before implementation
-- Follow twada's TDD methodology: Red → Green → Refactor
-- Commit after confirming the test fails
-- Write minimal implementation to pass the test
+### 4. Honest & Secure
+- State clearly when something is impossible, unknown, or unverified. Never proceed on assumption
+- Never compromise on security. Do not write code with known vulnerabilities
 
-### Security-First
-- Never compromise on security
-- Never write code containing vulnerabilities
-
----
-
-## Testing Rules
-
-- Minimize the use of mocks
-- **Database mocking is prohibited** - Use actual databases for testing
-- Mocks are only allowed when unavoidable (e.g., external APIs)
+### 5. Use Current Sources
+- For libraries / APIs / CLIs, check current docs via **context7 / deepwiki** when uncertain
+- Ground answers in sources you just read, not in training-data memory
 
 ---
 
-## Comment Rules
+## Workflow
 
-- **Write Why**: Document the reasoning and intent behind decisions
-- Comments that only explain What (processing content) are allowed only for:
-  - Complex processing spanning multiple lines
-  - Complex logic with multiple control statements
-- No comments needed for self-explanatory code
+### Git
+- Work on feature branches and merge to main via pull requests
+- Make small, frequent commits per logical unit
+- Use Conventional Commit prefixes (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `perf:`, `test:`, `build:`, `ci:`) for commits and PR titles
+- Follow the repository's language conventions
+- Prose must add what the diff does not already convey — delete sentences that just narrate the diff
+- **History-rewriting operations (`--amend`, `--force`, `reset --hard`, etc.) are blocked by the harness.** Stack a new commit for fixes; for already-published commits, use `revert`
+- PR description must include `Why` and `What` (change outline + watch-out points)
+  - If `Why` is unknown, confirm with the user before finalizing
+  - Optionally add a brief `Notes for reviewers` (complex logic, domain-critical areas, follow-ups)
+  - Do not add a `Test plan` section
 
----
+### Comments
+- Document **Why** (intent and reasoning)
+- Skip self-evident **What** comments. Exception: multi-line complex processing or intricate control flow
 
-## JavaScript/TypeScript Rules
-
-- Always use the packageManager defined in the project
-- **`npx` is prohibited**: Commands that download and execute tools on-the-fly pose security risks
-- Only use tools already installed in the project
-
----
-
-## Git Rules
-
-### Workflow
-
-- **Never work directly on main branch** - Create pull requests for each feature/fix
-- Make small, frequent commits per logical unit of work
-- **History rewriting is prohibited**: Do not use `--amend`, `--force`, or any commands that alter commit history
-
-### Writing commit messages and PRs (applies to both)
-
-- **Conventional commit prefix**: `feat:`, `fix:`, `build:`, `chore:`, `ci:`, `docs:`, `refactor:`, `perf:`, `test:`
-- **Language**: Follow the rules and conventions of the repository
-- Prose must add what the diff / code does not convey. If a sentence only narrates what the artifact already shows, delete it.
-
-### Pull Request specifics
-
-- PR descriptions must include:
-    - `Why`: reason for the change.
-    - `What`: outline of the change plus the important / watch-out points. Do not exhaustively list every file or implementation detail — the diff already shows them.
-- Optional `Notes for reviewers` to highlight places where the code alone does not convey intent, areas that need especially careful review (e.g. complex logic, domain-critical changes), or follow-up work. Keep it brief.
-- Do not add a `Test plan` section.
-- If `Why` is unknown, ask the user before finalizing the PR description.
+### JavaScript / TypeScript
+- Run via the project's `packageManager`
+- Use only tools already installed in the project (`npx` / `pnpx` on-the-fly execution is blocked by the harness)
 
 ---
 
-## Always Follow
+## Tooling
 
-### Use Latest Practices
-- Research and use the latest features and patterns
-- Leverage context7, deepwiki for documentation reference
-- Prefer modern best practices over legacy approaches
+### MCP / Plugin Routing
 
-### Be Honest
-- Clearly state "I cannot do this" or "This is not possible" when applicable
-- Never proceed based on assumptions
-- Ask questions when something is unclear
+| Task | Use |
+| --- | --- |
+| Library / API / SDK docs | `context7` |
+| GitHub repo understanding & Q&A | `deepwiki` (`ask_question`, `read_wiki_contents`) |
+| Broad web search / third-party info | `o3-search`, `gpt-5-search` |
+| Browser automation / UI verification | Playwright MCP |
+| Stuck, second opinion, parallel implementation | `codex-rescue` subagent |
+| PR review / security perspective | `pr-review-toolkit`, `security-guidance` agents |
+| Large-scale code exploration | `Explore` subagent (up to 3 in parallel) |
 
-### Answer Questions First
-- When the user asks a question (especially ending with `?`), answer the question first
-- Do not start working without permission
-- After answering, propose work if necessary
+Consider these before doing it yourself.
+
+### Memory (`~/.claude/memory/`)
+- Save user corrections / confirmations of non-obvious behavior as **feedback** (always pair the rule with its Why and applicable conditions)
+- Save deadlines, stakeholders, and context that cannot be read from code as **project** memory (use absolute dates)
+- Do not save anything derivable from code, git history, or CLAUDE.md
+- Before relying on a memory, verify it still matches reality; update or delete it if it has drifted
 
 ---
 
-**Philosophy**: Agent-first design, parallel execution, plan before action, test before code, security always.
+**Philosophy**: Plan first, delegate widely, parallelize aggressively, verify with current sources.


### PR DESCRIPTION
## Why

Opus 4.7 interprets instructions literally and does not extend them implicitly. Anthropic's current prompting guidance recommends keeping CLAUDE.md tight (~5 core principles), writing the desired behavior directly instead of stacking negatives, and stating things like parallel tool use explicitly. The existing CLAUDE.md leaned on prohibitions, duplicated Claude Code defaults, and repeated rules already enforced by `settings.json` deny rules + the `ccgate` PermissionRequest hook.

## What

- Restructure into three sections: **Core Principles (5)** / **Workflow** / **Tooling**
- Rewrite prohibitions as positive guidance (e.g. "Never work directly on main" → "Work on feature branches and merge via PRs")
- Drop the redundant "critical bans" list; rules already enforced by the harness (`npx`/`pnpx`, `--amend`, `--force`, `reset --hard`) are now mentioned inline in the Git / JS-TS workflow as harness-blocked, paired with their alternative
- Add explicit guidance for **parallel tool calls** with concrete examples — Opus 4.7 needs this stated to actually parallelize
- Add a **MCP / Plugin routing** table covering `context7`, `deepwiki`, `o3-search`, Playwright MCP, `codex-rescue`, `pr-review-toolkit`, `security-guidance`, and `Explore`
- Add a **Memory policy** section for `~/.claude/memory/` (feedback / project save criteria, drift checks)
- Trim 99 → 77 lines

## Notes for reviewers

- The harness-blocked list relies on `config/.claude/settings.json` `permissions.deny` and ccgate continuing to block these commands. If those guards are loosened later, the inline mention in CLAUDE.md should be revisited.
- Behavior verification is by running new Claude Code sessions and observing whether parallelization, plugin routing, and PR template adherence emerge naturally; no automated test applies.