### PR TITLE
chore(claude): update enabled plugins and block disabled superpowers skills

### DIFF
--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -166,6 +166,17 @@
     "defaultMode": "acceptEdits"
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -c 'if (.tool_input.skill // \"\" | test(\"^superpowers:(using-git-worktrees|finishing-a-development-branch)$\")) then {hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:\"This skill is disabled by user settings.\"}} else {} end'"
+          }
+        ]
+      }
+    ],
     "PermissionRequest": [
       {
         "matcher": "",
@@ -212,7 +223,6 @@
     "typescript-lsp@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
-    "security-guidance@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
@@ -220,7 +230,14 @@
     "claude-md-management@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "mcp-tools@izumin5210-dotfiles": true,
-    "codex@openai-codex": true
+    "codex@openai-codex": true,
+    "linear@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "session-report@claude-plugins-official": true,
+    "datadog@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "izumin5210-dotfiles": {
@@ -239,9 +256,8 @@
   "language": "japanese",
   "sandbox": {
     "filesystem": {
-      "allowWrite": [
-        "~/.local/share/pnpm"
-      ]
+      "allowWrite": ["~/.local/share/pnpm"]
     }
-  }
+  },
+  "effortLevel": "xhigh"
 }

--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -232,7 +232,6 @@
     "mcp-tools@izumin5210-dotfiles": true,
     "codex@openai-codex": true,
     "linear@claude-plugins-official": true,
-    "pyright-lsp@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true,
     "session-report@claude-plugins-official": true,
     "datadog@claude-plugins-official": true,


### PR DESCRIPTION
## Why

- Add a few more plugins to the tracked `enabledPlugins` set.
- superpowers' `using-git-worktrees` and `finishing-a-development-branch` skills don't fit my workflow and I want them suppressed. `skillOverrides` does not apply to plugin-provided skills (verified empirically), so I'm switching to a PreToolUse hook that inspects the `Skill` tool input and denies these two by name.

## What

- `enabledPlugins`: add linear, superpowers, session-report, datadog, ralph-loop.
- `hooks.PreToolUse`: add a hook with matcher `Skill`. When `tool_input.skill` matches `superpowers:using-git-worktrees` or `superpowers:finishing-a-development-branch`, it returns `permissionDecision: deny`.
- Minor: set `effortLevel: "xhigh"` explicitly and inline `sandbox.filesystem.allowWrite`.

## Notes for reviewers

- To disable more skills later, just add them to the alternation inside the hook's jq regex: `^superpowers:(...|...)$`.
- Hook changes may not be picked up by the current session's watcher; opening `/hooks` once or restarting Claude Code reloads them.