### PR TITLE
chore(claude): use TS7 native (tsgo) and gopls-lazy for LSP

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,6 +12,50 @@
       "version": "1.0.0",
       "source": "./claude-plugins/mcp-tools",
       "category": "productivity"
+    },
+    {
+      "name": "typescript-native-lsp",
+      "description": "TypeScript 7 native (tsgo) language server via `tsc --lsp`",
+      "version": "1.0.0",
+      "source": "./claude-plugins/typescript-native-lsp",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "typescript": {
+          "command": "tsc",
+          "args": ["--lsp", "--stdio"],
+          "env": {
+            "GOMAXPROCS": "2",
+            "GOMEMLIMIT": "6GiB"
+          },
+          "extensionToLanguage": {
+            ".ts": "typescript",
+            ".tsx": "typescriptreact",
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".mts": "typescript",
+            ".cts": "typescript",
+            ".mjs": "javascript",
+            ".cjs": "javascript"
+          }
+        }
+      }
+    },
+    {
+      "name": "gopls-lazy-lsp",
+      "description": "Go language server using the gopls-lazy proxy",
+      "version": "1.0.0",
+      "source": "./claude-plugins/gopls-lazy-lsp",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "gopls-lazy": {
+          "command": "gopls-lazy",
+          "extensionToLanguage": {
+            ".go": "go"
+          }
+        }
+      }
     }
   ]
 }

--- a/claude-plugins/gopls-lazy-lsp/.claude-plugin/plugin.json
+++ b/claude-plugins/gopls-lazy-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "gopls-lazy-lsp",
+  "description": "Go language server using the gopls-lazy proxy",
+  "version": "1.0.0",
+  "author": {
+    "name": "izumin5210"
+  }
+}

--- a/claude-plugins/typescript-native-lsp/.claude-plugin/plugin.json
+++ b/claude-plugins/typescript-native-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "typescript-native-lsp",
+  "description": "TypeScript 7 native (tsgo) language server via `tsc --lsp`",
+  "version": "1.0.0",
+  "author": {
+    "name": "izumin5210"
+  }
+}

--- a/claude-plugins/typescript-native-lsp/README.md
+++ b/claude-plugins/typescript-native-lsp/README.md
@@ -1,0 +1,18 @@
+# typescript-native-lsp
+
+TypeScript 7 の native 言語サーバ (tsgo) を Claude Code の LSP として使うためのプラグイン。
+
+`command` は PATH 上の `tsc`（dotfiles の `node_modules/.bin`、devDependencies の `typescript@7`）を解決し、`tsc --lsp --stdio` で起動する。TS7 は古典的な `tsserver` を廃止したため `typescript-language-server` / `vtsls` では駆動できず、native LSP を直接起動している。
+
+## メモリ・継続負荷チューニング (`env`)
+
+tsgo は Go 製で、既定では `GOMAXPROCS`（全論理コア）ぶんの並列で型解析を行い、その中間結果を保持するため巨大プロジェクトで RSS と継続 CPU 負荷が大きくなりやすい。レイテンシより「消費メモリの小ささ・継続的なマシン負荷の小ささ」を優先するため、この LSP プロセスにだけ以下の Go ランタイム環境変数を渡している（グローバルに設定すると gopls / go build 等すべての Go ツールを縛るため、`lspServers.env` でスコープする）。
+
+| 変数 | 値 | 意図 |
+| --- | --- | --- |
+| `GOMAXPROCS` | `2` | 並列型チェックのコア数を制限し、並列チェッカーのメモリと継続 CPU を削減 |
+| `GOMEMLIMIT` | `6GiB` | RSS の soft 上限。超過時に GC を積極化してメモリを解放（低すぎると GC 過多で CPU が増えるため余裕を持たせた値） |
+
+`GOGC` の引き下げはメモリを減らせるが GC 頻度が上がり継続 CPU 負荷が増える（方針に反する）ため採用していない。
+
+`tsgo` は 7.1 系で並列チェッカー数を直接指定する `--checkers` / `--singleThreaded` フラグを追加予定だが、7.0.2 の LSP は未対応（`-pipe -pprofDir -socket -stdio` のみ）。そちらが安定したら env ではなくフラグ指定へ移行できる。

--- a/config/.claude/settings.json
+++ b/config/.claude/settings.json
@@ -229,7 +229,7 @@
     "datadog@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
-    "gopls-lsp@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": false,
     "linear@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
@@ -237,9 +237,11 @@
     "security-guidance@claude-plugins-official": true,
     "session-report@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": false,
     "codex@openai-codex": true,
-    "mcp-tools@izumin5210-dotfiles": true
+    "mcp-tools@izumin5210-dotfiles": true,
+    "typescript-native-lsp@izumin5210-dotfiles": true,
+    "gopls-lazy-lsp@izumin5210-dotfiles": true
   },
   "extraKnownMarketplaces": {
     "izumin5210-dotfiles": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,9 @@
 onlyBuiltDependencies:
   - puppeteer
+# TypeScript 7 (tsgo) native packages are first-party (Microsoft) and needed
+# promptly for the `tsc --lsp` language server; exempt them from pnpm's default
+# 1-day minimumReleaseAge supply-chain guard. (glob + version union is rejected
+# by pnpm, so the per-platform binaries are matched by name pattern.)
+minimumReleaseAgeExclude:
+  - typescript@7.0.2
+  - "@typescript/typescript-*"


### PR DESCRIPTION
## Why

- Update the TS / Go LSP setup while keeping memory usage and continuous machine load low on large projects (prioritizing low load over latency).
- The official `typescript-lsp` uses `typescript-language-server` (a tsserver wrapper), but **TS7 dropped tsserver**, so it can no longer drive TS7. The TS7 native LSP (tsgo) must be launched directly.
- For Go, use `gopls-lazy` (an LSP proxy in front of gopls) to keep gopls memory/load bounded in large monorepos.

## What

- Disable the official `typescript-lsp` / `gopls-lsp` plugins and add **two custom LSP plugins** to the marketplace.
  - **`typescript-native-lsp`**: runs `tsc --lsp --stdio` (the PATH-exposed devDependency = TS7). Caps memory / continuous CPU by scoping `GOMAXPROCS=2` and `GOMEMLIMIT=6GiB` via `env` **to this LSP process only** (the `--checkers` flag isn't supported by the 7.0.2 LSP, so env vars are used instead).
  - **`gopls-lazy-lsp`**: runs `gopls-lazy` (already pinned in aqua; it proxies to the PATH `gopls`).
- Add `minimumReleaseAgeExclude` to `pnpm-workspace.yaml` (TS7 first-party packages only) to bypass pnpm's default 1-day minimumReleaseAge guard.
- Each plugin's rationale is documented in `claude-plugins/typescript-native-lsp/README.md` (marketplace.json is pure JSON and can't hold comments).

## Notes for reviewers

- Changes take effect only **after restarting Claude Code**. Also, the marketplace is GitHub-sourced, so the new plugins appear in other sessions only **once this is merged to `main`** (uncommitted local edits are not visible).
- `tsc` resolves to the PATH-exposed global TS7 from the dotfiles, so every project uses the TS7 native LSP (it no longer resolves the project-local `typescript` — this is intended).
- The memory env values (P=2 / 6GiB) are provisional; adjust per the lever notes in the README if it feels heavy/slow.
- Unrelated working-tree changes (`model: opus`, `allowBuilds`, the `pnpm-lock.yaml` context7 sync, nvim, etc.) are intentionally excluded from this PR.
