### PR TITLE
fix(ws): start the herdr server in its own session

### DIFF
--- a/config/.bin/ws
+++ b/config/.bin/ws
@@ -142,7 +142,7 @@ list_remote() {
   for host in "${host_list[@]}"; do
     (
       ssh -o ConnectTimeout=3 -o BatchMode=yes "$host" \
-        'zsh -lic "herdr workspace list"' 2>/dev/null |
+        'herdr workspace list' 2>/dev/null |
         jq -r '.result.workspaces[]?.label' 2>/dev/null |
         while IFS= read -r label; do
           printf "\e[0;33m%s\e[m   %s (%s)\t%s\t%s\n" "$ICON_CLOUD" "$label" "$host" "$host" "$label"

--- a/config/.bin/ws
+++ b/config/.bin/ws
@@ -43,6 +43,25 @@ die_split_brain() {
     "  ps ax -o pid,lstart,command | grep 'herdr.* server'"
 }
 
+# herdr 自身がサーバを起動するときは setsid でセッションを分離している。同じ形で
+# 起動しないと、`herdr --remote` の attach 時に「SSH が切れるとサーバごと落ちうる」
+# として再起動を促される。
+spawn_server() {
+  local bin
+  bin=$(command -v herdr) || die "herdr not found in PATH"
+
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "$bin" server </dev/null >/dev/null 2>&1 &
+  elif command -v perl >/dev/null 2>&1; then
+    # macOS には setsid(1) が無い。先に fork するのは、プロセスグループリーダーだと
+    # setsid(2) が EPERM で失敗するため。
+    perl -e 'use POSIX qw(setsid); fork && exit 0; setsid() or die "setsid: $!\n"; exec @ARGV or die "exec: $!\n"' \
+      "$bin" server </dev/null >/dev/null 2>&1 &
+  else
+    nohup "$bin" server </dev/null >/dev/null 2>&1 &
+  fi
+}
+
 ensure_server() {
   herdr workspace list >/dev/null 2>&1 && return 0
   # herdr の中にいる (= サーバーは必ず存在する) / すでにサーバーが動いている場合に
@@ -50,8 +69,7 @@ ensure_server() {
   if in_herdr || herdr_server_running; then
     die_split_brain "herdr server に到達できません (socket: ${HERDR_SOCKET_PATH:-default})"
   fi
-  nohup herdr server </dev/null >/dev/null 2>&1 &
-  disown
+  spawn_server
   local i
   for i in {1..30}; do
     herdr workspace list >/dev/null 2>&1 && return 0

--- a/config/.bin/ws
+++ b/config/.bin/ws
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 #
-# hws — herdr workspace picker (tm の herdr 版)
+# ws — herdr workspace picker (tm の herdr 版)
 #
 # fzf でローカル workspace + ghq リポジトリ + remote SSH ホストを横断選択して
 # workspace を切替/作成する。
 #
 # Usage:
-#   hws           対話ピッカーを起動
-#   hws <name>    <name> と一致する workspace を focus。無ければ $PWD で作成
+#   ws            対話ピッカーを起動
+#   ws <name>     <name> と一致する workspace を focus。無ければ $PWD で作成
 #
 # 環境変数:
 #   HWS_REMOTE_HOSTS  カンマ区切りの SSH ホスト名 (未設定なら TM_REMOTE_HOSTS を継承)
@@ -22,7 +22,7 @@ in_herdr() { [[ -n "${HERDR_ENV:-}" ]]; }
 
 # popup はコマンドの終了と同時に閉じてしまい、stderr に書くだけでは読む間がない。
 die() {
-  printf 'hws: %s\n' "$@" >&2
+  printf 'ws: %s\n' "$@" >&2
   if [[ -t 0 ]]; then
     read -rsn1 -p 'press any key to close...' _ || true
     printf '\n' >&2


### PR DESCRIPTION
## Why

Attaching to rabbithouse prompts on every connect:

```
the remote server was started by a herdr build that may not survive SSH connection loss.
restart it so network drops disconnect only this client.
restart the remote server now? [y/N]
```

herdr decides this from a capability the running server reports, and the implementation is a single check (`src/platform/mod.rs`):

```rust
pub fn current_process_is_detached_server_daemon() -> bool {
    unsafe { libc::getsid(0) == libc::getpid() }   // am I a session leader?
}
```

herdr's own spawn path (`src/server/autodetect.rs`) runs the server through `detach_server_daemon_command`, i.e. `pre_exec(setsid)`, so a server it starts passes that check. `ws` started it with `nohup herdr server &`, which only ignores SIGHUP and leaves the process in the session of whatever shell ran `ws`. Measured on rabbithouse:

```
pid=66246  ppid=1  pgid=66243  tty=??      # pgid != pid -> not a session leader
```

So every remote attach asks to restart a server that was started by our own picker.

## What

- Add `spawn_server` and use it from `ensure_server` instead of `nohup ... &`:
  - `setsid(1)` where it exists (Linux)
  - perl fallback for macOS, which has no `setsid(1)`. It forks first because `setsid(2)` fails with `EPERM` when called by a process group leader
  - plain `nohup` as a last resort so `ws` still works somewhere without either
- Resolve the binary with `command -v herdr` so a missing herdr fails immediately instead of after a 3-second poll loop.
- Finish the `hws` → `ws` rename: error messages still printed `hws:`.
- Drop the `zsh -lic` wrapper from `list_remote`. Since #2947 put PATH in `.zshenv`, `ssh host 'herdr workspace list'` resolves herdr by itself, and the interactive login shell was printing `can't change option: zle` on every remote listing.

## Notes for reviewers

- Verified from a non-interactive script, which is how `ws` actually runs: the spawned process comes out as `pid=51418 ppid=1 pgid=51418 tty=??`, versus `pgid != pid` for the old `nohup` form. An end-to-end run of `ws` with stubbed `herdr`/`pgrep` produced the same result.
- aqua's `bin/herdr` is a shim, but `aqua-proxy` execs rather than forks (checked: running an aqua tool leaves exactly one process), so session leadership carries through to the real binary.
- This only affects servers started from now on. An already-running server keeps its session: a process cannot be moved into a new one after the fact, so the prompt stays until that server is restarted or handed off with `herdr --remote <host> --handoff`.
- `HWS_REMOTE_HOSTS` keeps its name; only the display name and error prefix changed.