### PR TITLE
feat(herdr): bind prev/next workspace to prefix+shift+p/n

### DIFF
--- a/config/.config/herdr/config.toml
+++ b/config/.config/herdr/config.toml
@@ -85,14 +85,20 @@ settings = "prefix+shift+s"
 # open_notification_target = "prefix+o"
 # workspace_picker = "prefix+w"
 # goto = "prefix+g"
-# new_workspace = "prefix+shift+n"
+# prefix+shift+n を next_workspace に譲るための退避先。
+# new_tab = "prefix+c" に shift を足した形になり、「shift = 一階層上」の規則に揃う。
+new_workspace = "prefix+shift+c"
 # new_worktree = "prefix+shift+g"
 # open_worktree = ""    # optional, unset by default
 # remove_worktree = ""  # optional, unset by default; opens confirmation
 # rename_workspace = "prefix+shift+w"
 # close_workspace = "prefix+shift+d"
-# previous_workspace = "" # optional, unset by default
-# next_workspace = ""     # optional, unset by default
+# tmux の `prefix+(` / `prefix+)` (switch-client -p/-n) 相当。tmux が記号キーで表していた
+# 「window より一つ上の階層の前後」を、herdr 既定の close_pane=prefix+x →
+# close_tab=prefix+shift+x と同じ「shift = 一階層上」の規則で表す。
+# つまり tab の prefix+p/n に shift を足したものが workspace の前後になる。
+previous_workspace = "prefix+shift+p"
+next_workspace = "prefix+shift+n"
 # previous_agent = ""     # optional, unset by default
 # next_agent = ""         # optional, unset by default
 # focus_agent = ""        # optional indexed binding, e.g. "prefix+alt+1..9"
@@ -104,7 +110,9 @@ settings = "prefix+shift+s"
 # switch_tab = "prefix+1..9"
 # switch_workspace = ""   # optional indexed binding, e.g. "prefix+shift+1..9"
 # close_tab = "prefix+shift+x"
-# rename_pane = "prefix+shift+p"
+# prefix+shift+p を previous_workspace に譲るための退避先。tmux の `prefix+,`
+# (rename-window) に寄せる。
+rename_pane = "prefix+comma"
 # edit_scrollback = "prefix+e"
 # prefix+hjkl は下の herdr-nav (nvim 対応版) に譲るため組み込みの focus_pane_* を無効化する。
 # config check は同一キーの衝突を報告しないので、空文字で明示的に外しておく必要がある。


### PR DESCRIPTION
## Why

A herdr workspace is the equivalent of a tmux session, but the only way to reach an
adjacent one was through a picker — the `ws` popup on `prefix+s`, `workspace_picker`
on `prefix+w`, or `goto` on `prefix+g`. There was no single-keystroke move to the
previous/next workspace, which is what `prefix+(` / `prefix+)` (`switch-client -p/-n`)
did in tmux.

herdr ships `previous_workspace` / `next_workspace` as built-in actions but leaves
them unbound by default.

## What

### Choosing the keys

herdr's own defaults already use "shift = one level up" in places:

| | pane | tab | workspace |
| --- | --- | --- | --- |
| close | `prefix+x` | `prefix+shift+x` | `prefix+shift+d` |
| prev/next | — | `prefix+p` / `prefix+n` | **unbound** |

Since `close` goes `x` → `shift+x` for pane → tab, prev/next extends the same way for
tab → workspace: `p`/`n` → `shift+p`/`shift+n`. This expresses what tmux encoded in
`(` and `)` — "previous/next one level above windows" — without punctuation keys.

I surveyed the alternatives. tmux is effectively the only tool that binds `(` / `)`
this way by default; it never became a wider convention (zellij uses a session-manager
plugin, WezTerm ships `SwitchWorkspaceRelative` unbound, and the vim world uses
`[` / `]` for prev/next). `[` / `]` was ruled out because `prefix+[` is copy-mode in
tmux muscle memory.

### Forced relocations

Both target keys were occupied by defaults, so two actions had to move:

| Action | Before (default) | After |
| --- | --- | --- |
| `previous_workspace` | unbound | `prefix+shift+p` |
| `next_workspace` | unbound | `prefix+shift+n` |
| `new_workspace` | `prefix+shift+n` | `prefix+shift+c` |
| `rename_pane` | `prefix+shift+p` | `prefix+comma` |

`prefix+shift+c` is one level above `new_tab = prefix+c`, so relocating `new_workspace`
there pulls it into the same "shift = one level up" rule rather than away from it.
`rename_pane` moves to `prefix+comma`, matching tmux's `prefix+,` (rename-window).

## Notes for reviewers

- **`herdr config check` does not report duplicate key bindings** (already noted in an
  existing comment in `config.toml`). Skipping either relocation would pass validation
  and silently break, which is why both were mandatory here.
- Verified: `herdr config check` → `config: ok`, and `herdr server reload-config` →
  `{"status":"applied","diagnostics":[]}`. Both `prefix+comma` and `prefix+shift+c`
  parse fine.
- There is no API that dumps the effective keymap (`herdr api` only exposes `snapshot`
  and `schema`), so the actual key presses — and whether prev/next wraps at the ends —
  still need a manual check.