### PR TITLE
feat(zsh): bind ws to ctrl-t s

### DIFF
--- a/config/.config/zsh/legacy/functions.zsh
+++ b/config/.config/zsh/legacy/functions.zsh
@@ -33,6 +33,16 @@ _tmux_session() {
 
 _register_keycommand '^tm' _tmux_session
 
+_herdr_workspace() {
+  _buffer_replace <<<"ws"
+  zle accept-line
+  zle reset-prompt
+}
+
+# herdr のセッション切り替え (config.toml の prefix+s) と揃える。herdr の中では
+# ctrl+t が prefix に食われてこの chord は発火しないが、そちらは popup が担当する。
+_register_keycommand '^ts' _herdr_workspace
+
 #  git interactive operations
 #--------------------------------
 _git_interactive_add() {


### PR DESCRIPTION
## Why

`tm` (the tmux session picker) can be launched from zsh with the `^tm` chord, so a bare
terminal has a one-keystroke path into a tmux session. Its herdr counterpart `ws` had no
such path — it was only reachable from inside herdr, via the `prefix+s` popup. Starting
herdr from a fresh terminal meant typing `ws` (or `herdr`) by hand.

## What

Adds a `^ts` ZLE widget that runs `ws`, mirroring `_tmux_session` (buffer-replace +
`accept-line`, which is what lets `ws` reach the terminal for its `exec herdr`).

The key is `s` rather than something tmux-flavoured because it lines up with herdr's own
session switching — `prefix+s` in `config/.config/herdr/config.toml` already opens the
`ws` popup, the same way tmux's `bind s run-shell "tm"` opens `tm`. So `ctrl-t s` means
"switch workspace/session" at every layer:

| Environment | `ctrl-t s` | Handled by |
| --- | --- | --- |
| bare zsh (no multiplexer) | `ws` → picker → `exec herdr` | this zsh chord |
| inside herdr | `ws` popup | `config.toml` `prefix+s` |
| inside tmux | `tm` | `tmux.conf` `bind s run-shell "tm"` |

Inside herdr, `ctrl+t` is swallowed as the herdr prefix, so the zsh chord never fires —
that is intentional, and the reason **no passthrough was added** on the herdr side. tmux
needs `bind m send-keys C-t m` (`tmux.conf:114`) for `^tm` precisely because tmux has
nothing else on `prefix+m`; `prefix+s` is already the right action in both multiplexers,
so nothing needs forwarding.

Only `config/.config/zsh/legacy/functions.zsh` changes; herdr and tmux configs are
untouched.

## Notes for reviewers

- `^T` alone stays bound to `fzf-file-widget`; `^T` was already a prefix key because of
  `^tm`, so this adds no new ambiguity. Verified in a real shell:

  ```
  "^T" fzf-file-widget
  "^Tm" _tmux_session
  "^Ts" _herdr_workspace
  ```

- The actual key press (bare terminal → `ctrl-t s` → fzf → herdr) still needs a manual
  check; only the binding registration was verified programmatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)