### PR TITLE
feat(claude): layer machine-local overrides onto ccgate config

### DIFF
--- a/bin/deploy-config-files
+++ b/bin/deploy-config-files
@@ -41,7 +41,7 @@ mkdir -p ~/.config
 # claude
 ./bin/ln-idempotently ./config/.claude ~/.claude
 # ccgate.jsonnet imports this machine-local file; jsonnet errors when it is missing
-[ -f ./config/.claude/ccgate.local.libsonnet ] || echo '{}' > ./config/.claude/ccgate.local.libsonnet
+[ -f ./config/.claude/ccgate.local.libsonnet ] || echo '{}' >./config/.claude/ccgate.local.libsonnet
 
 # codex
 ./bin/ln-idempotently ./config/.codex ~/.codex

--- a/bin/deploy-config-files
+++ b/bin/deploy-config-files
@@ -40,6 +40,8 @@ mkdir -p ~/.config
 
 # claude
 ./bin/ln-idempotently ./config/.claude ~/.claude
+# ccgate.jsonnet imports this machine-local file; jsonnet errors when it is missing
+[ -f ./config/.claude/ccgate.local.libsonnet ] || echo '{}' > ./config/.claude/ccgate.local.libsonnet
 
 # codex
 ./bin/ln-idempotently ./config/.codex ~/.codex

--- a/config/.claude/ccgate.jsonnet
+++ b/config/.claude/ccgate.jsonnet
@@ -1,3 +1,10 @@
+// Machine-local overrides live in ccgate.local.libsonnet (untracked;
+// `bin/deploy-config-files` seeds `{}` when missing). jsonnet fails to
+// evaluate when the import target is missing, so the seed is mandatory.
+// Use `provider+:` there to patch provider fields without repeating the
+// whole block.
+local overrides = import 'ccgate.local.libsonnet';
+
 {
   ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
 
@@ -48,4 +55,4 @@
   environment: [
     '**Trusted repo**: The git repository the session started in.',
   ],
-}
+} + overrides


### PR DESCRIPTION
## Why

ccgate's provider needs to differ per machine: the corp laptop must route permission evaluations through the corp LiteLLM gateway (with its own auth helper and the dated model id) instead of hitting Anthropic directly, while personal machines keep the vendor default. ccgate evaluates its config with go-jsonnet, so the shared config can import a machine-local file and branch that way — no support for host detection (extVars / native hostname) exists in ccgate itself.

## What

- `config/.claude/ccgate.jsonnet` imports `ccgate.local.libsonnet` and layers it on top of the shared object. The local file is machine-specific and automatically untracked (the `.gitignore` allowlist under `/config/.claude/*` never matches it). Per-field patching via `provider+:` keeps the shared `name` / `model` defaults intact on machines that only need a few overrides.
- `bin/deploy-config-files` seeds an empty `{}` local file when missing, because a missing jsonnet import target is an evaluation error, not a silent no-op.

⚠️ After this lands, run `./bin/deploy-config-files` on each machine right after pulling — until the seed file exists, every ccgate hook invocation fails to evaluate the config.

## Notes for reviewers

Verified with go-jsonnet (the engine ccgate embeds): the merged provider block on the corp machine, the empty-override case, and live hook evaluations logged with the overridden model id through the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)