### PR TITLE
fix(ws): stop waiting on the remote probe after selection

### DIFF
--- a/config/.bin/ws
+++ b/config/.bin/ws
@@ -135,13 +135,21 @@ list_repos() {
 list_remote() {
   local hosts="${HWS_REMOTE_HOSTS:-${TM_REMOTE_HOSTS:-}}"
   [[ -z "$hosts" ]] && return 0
+
+  # ssh の -o ConnectTimeout は TCP connect とハンドシェイクにしか効かず、名前解決は
+  # 対象外。Tailscale が落ちていると *.ts.net の scoped resolver (100.100.100.100) が
+  # 無応答になり、getaddrinfo が macOS 既定の 30 秒まで粘る。外から丸ごと打ち切るしかない。
+  # 5 秒は ConnectTimeout の 3 秒 + リモートの herdr が応答するまでの猶予。
+  local ssh_timeout=()
+  command -v timeout >/dev/null 2>&1 && ssh_timeout=(timeout 5)
+
   local tmpdir
   tmpdir=$(mktemp -d)
   IFS=',' read -ra host_list <<<"$hosts"
   local host
   for host in "${host_list[@]}"; do
     (
-      ssh -o ConnectTimeout=3 -o BatchMode=yes "$host" \
+      "${ssh_timeout[@]}" ssh -o ConnectTimeout=3 -o BatchMode=yes "$host" \
         'herdr workspace list' 2>/dev/null |
         jq -r '.result.workspaces[]?.label' 2>/dev/null |
         while IFS= read -r label; do
@@ -216,8 +224,12 @@ select_and_dispatch() {
     --preview-window right:60%
   )
 
+  # $(producer | fzf) は fzf が抜けても producer の終了まで待つ。list_remote は ssh の
+  # 結果を一時ファイルに溜めてから出すので、fzf が閉じても SIGPIPE で死なない。つまり
+  # 一覧の先頭を即決しても remote プローブぶん焦らされる。プロセス置換なら待ち対象が
+  # fzf だけになり、残った ssh は孤児として勝手に片付く。
   local selected
-  selected=$(build_list | fzf "${fzf_opts[@]}") || true
+  selected=$(fzf "${fzf_opts[@]}" < <(build_list)) || true
   [[ -z "$selected" ]] && return 0
 
   local kind name path


### PR DESCRIPTION
## Why

Picking a workspace in `ws` sometimes stalled for ~30s before the switch actually happened.

`ssh -o ConnectTimeout=3` only budgets the TCP connect and the protocol handshake — name resolution is outside it. With Tailscale logged out, `*.ts.net` still routes through the scoped resolver installed at `/etc/resolver/ts.net`:

```
resolver #9
  domain   : ts.net
  nameserver[0] : 100.100.100.100
```

That resolver no longer answers, so `getaddrinfo()` waits out macOS' 30s default:

```
$ time ssh -o ConnectTimeout=3 -o BatchMode=yes rabbithouse 'herdr workspace list'
ssh: Could not resolve hostname rabbithouse.tailb77f23.ts.net
30.020 total
```

`host(1)` returns NXDOMAIN in 0.3s because libresolv ignores the scoped resolver, which is why this looks fine from `dig`/`host` but hangs under ssh.

By itself that would only delay remote entries showing up in the picker. It blocked the *switch* because of two things stacking:

- `list_remote` buffers each ssh into `$tmpdir/$host` and only writes to stdout after `wait`, so fzf closing the read end never breaks the producer out with SIGPIPE.
- `$(build_list | fzf ...)` waits for the entire pipeline, not just fzf. Selecting the very first entry still parks on `build_list`.

## What

- `select_and_dispatch`: `$(build_list | fzf)` → `$(fzf < <(build_list))`. The command substitution now only waits for fzf; the leftover ssh is orphaned and reaped on its own.
- `list_remote`: wrap ssh in `timeout 5` when available, since no ssh option bounds `getaddrinfo`. Falls back to bare ssh where `timeout` is absent — the empty-array expansion is safe under `set -u` on bash 4.4+.

Measured end to end by driving the real script with a stub `fzf`, worst case (Tailscale down):

| | before | after |
|---|---|---|
| select the first entry immediately | 31s | **0s** |
| read the whole list, then ESC | 31s | 6s |

## Notes for reviewers

The reachable-host path is **not** verified — Tailscale is logged out here, so I could not confirm a successful remote listing still renders. The diff only prepends `timeout 5`, so the happy path should be unchanged, but on a link where connect + the remote `herdr workspace list` exceeds 5s the host will now silently drop out of the picker instead of eventually appearing. Worth a sanity check next time the tailnet is up; the constant is easy to raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
