### PR TITLE
fix: revert go-delve/delve to v1.26.3

### DIFF
--- a/config/.config/aquaproj-aqua/aqua-checksums.json
+++ b/config/.config/aquaproj-aqua/aqua-checksums.json
@@ -796,28 +796,28 @@
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/pnpm/pnpm/v11.19.0/pnpm-darwin-arm64.tar.gz",
-      "checksum": "00075435E24D20F5D369C9AEC1EE1C29EBB78B52DE8EA9807013FC70187EA0E5",
+      "id": "github_release/github.com/pnpm/pnpm/v11.20.0/pnpm-darwin-arm64.tar.gz",
+      "checksum": "4BC97FEA72E5C92EEC1FEFC8D410C35D01E0D0D52F3160C59F38C32DB58B5CD2",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/pnpm/pnpm/v11.19.0/pnpm-linux-arm64.tar.gz",
-      "checksum": "1B1630C3AE133448A9445911499AB2D59BD77F860ABBD595DBC89DA4EB82C22B",
+      "id": "github_release/github.com/pnpm/pnpm/v11.20.0/pnpm-linux-arm64.tar.gz",
+      "checksum": "F00FC2041BB41742B7943BF2BB24183AD20320E8384824A8031EB94EDF2F57A5",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/pnpm/pnpm/v11.19.0/pnpm-linux-x64.tar.gz",
-      "checksum": "01562375E2B05B5CDC8D67E0BBFED549221C8A739B485EE0DAC13D32D383EC24",
+      "id": "github_release/github.com/pnpm/pnpm/v11.20.0/pnpm-linux-x64.tar.gz",
+      "checksum": "B4AD6AD2B21DB2F8CD50AF416C3AA148BA704C31C84893F465A770A01C2C4572",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/pnpm/pnpm/v11.19.0/pnpm-win32-arm64.zip",
-      "checksum": "280FEA20D193319D38A4858E5800503C73F74EE1B47E1717179FBEB866786419",
+      "id": "github_release/github.com/pnpm/pnpm/v11.20.0/pnpm-win32-arm64.zip",
+      "checksum": "5B39112B344AC95CC44531464AE9C19520ED062F3956A528F7CA19BAF2802AF6",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/pnpm/pnpm/v11.19.0/pnpm-win32-x64.zip",
-      "checksum": "00BA922EF628D6879332AF58CC3FCFE4177C71677F714406467047EB39902D22",
+      "id": "github_release/github.com/pnpm/pnpm/v11.20.0/pnpm-win32-x64.zip",
+      "checksum": "EA2528BDC3D96A1FF3C35587DC48CA692B39D77F08F26DF4ADEAAA9EB427024E",
       "algorithm": "sha256"
     },
     {
@@ -1256,33 +1256,33 @@
       "algorithm": "sha256"
     },
     {
-      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.222/darwin-arm64/claude",
-      "checksum": "C66A6CC6FA2E8145BB1A6E77831F2CAF4B83690FF04650500DFA6E2C05CA997C",
+      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.223/darwin-arm64/claude",
+      "checksum": "FCBE0B8D47570C501302DD1AD31CC26AC2810F022C45FA253936A6961DEE32BF",
       "algorithm": "sha256"
     },
     {
-      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.222/darwin-x64/claude",
-      "checksum": "36BFC6482A25730DBB1CEE72589E522C66C45A4DC9EBFDD8A76A8113B01B6188",
+      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.223/darwin-x64/claude",
+      "checksum": "350E657428A6D34F7CF71F6738C5EBB6A1952CCB12FC1747F64297E065B1846F",
       "algorithm": "sha256"
     },
     {
-      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.222/linux-arm64-musl/claude",
-      "checksum": "A3C3E3202AE8842A5E9D2B4CE1DCEA9FA00D4E0AE27B5B3E8D778332BA3BB23C",
+      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.223/linux-arm64-musl/claude",
+      "checksum": "F41692EAB23EBCD836D342FBC494D8783B1F19EFB13D04FBF8461D2806CCB586",
       "algorithm": "sha256"
     },
     {
-      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.222/linux-arm64/claude",
-      "checksum": "A04BE0A8D7FE0259571AB7411D51D85658D71A4A26CE62B60C908290372E6016",
+      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.223/linux-arm64/claude",
+      "checksum": "60E83D8DB0E894D0E54413E5E7DAA256D180DB660F51E139A51B614FC30CF3AC",
       "algorithm": "sha256"
     },
     {
-      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.222/linux-x64-musl/claude",
-      "checksum": "E0B0FB4005E1AC0EBCEE136254C638722F1C49E171A23D0843C605D72AAC9029",
+      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.223/linux-x64-musl/claude",
+      "checksum": "8A4E561E8AF19746D2DEFCF1A5661F5C0384C9C26DADD87D45E11B67802AD147",
       "algorithm": "sha256"
     },
     {
-      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.222/linux-x64/claude",
-      "checksum": "10CAAE8F22B915C26BFFF0E013A4D45608C4F1AE287583626569156F447730E5",
+      "id": "http/storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/2.1.223/linux-x64/claude",
+      "checksum": "98226474F802E3094D6A86C5ADE8883C16206D0FCB5C400B7401C800063E99D7",
       "algorithm": "sha256"
     },
     {

--- a/config/.config/aquaproj-aqua/aqua.yaml
+++ b/config/.config/aquaproj-aqua/aqua.yaml
@@ -13,7 +13,7 @@ packages:
   # go
   - name: golang/go@go1.26.5
   - name: golang.org/x/tools/gopls@v0.23.0
-  - name: go-delve/delve@v1.27.0
+  - name: go-delve/delve@v1.26.3
   - name: golangci/golangci-lint@v2.12.2
   - name: nametake/golangci-lint-langserver@v0.0.12
   # javascript

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,11 @@
     {
       "matchPackageNames": ["anthropics/claude-code", "openai/codex"],
       "minimumReleaseAge": "12 hours"
+    },
+    {
+      "description": "delve stopped publishing release assets again at v1.27.0, but aqua-registry only routes <=1.26.1 to go_install and still resolves newer versions via github_release. `aqua update-checksum` therefore fails on the missing checksums.txt and blocks every aqua PR. Drop this rule once the registry covers v1.27+.",
+      "matchPackageNames": ["go-delve/delve"],
+      "allowedVersions": "<=1.26.3"
     }
   ],
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
## Why

Since #2783 bumped `go-delve/delve` to v1.27.0, **CI fails on every PR that touches `aqua.yaml`** (reproduced on #3012, #3017, #3020).

```
ERR update checksums package_name=go-delve/delve package_version=v1.27.0
    error="download a checksum file: the asset isn't found: checksums.txt"
ERR aqua failed error="it failed to update some packages' checksums"
```

delve published release binaries only for v1.26.2 and v1.26.3, and **went back to source-only releases at v1.27.0**. The aqua-registry definition routes only `semver("<= 1.26.1")` to `go_install` and still resolves anything newer through `github_release` + `checksums.txt`, so v1.27.0 goes looking for an asset that does not exist. This is still unfixed on registry HEAD.

`update-checksum-action` updates the checksums of every package in `aqua.yaml`, not just the ones in the diff, so this single broken package takes down every aqua PR.

#2783 itself was auto-merged over a red CI during a GitHub Actions outage, when the required check reported `skipped` (see Notes). That left `main` inconsistent: `aqua.yaml` at v1.27.0, `aqua-checksums.json` at v1.26.3.

## What

- Revert #2783 and bring `go-delve/delve` back to v1.26.3
  - `aqua-checksums.json` on `main` is still at v1.26.3, so this restores consistency
- Add a Renovate `packageRule` constraining `go-delve/delve` to `<=1.26.3`
  - Without it Renovate re-raises the same update immediately. #3013 is already open for v1.27.1, which has no assets either and would not help.
  - Drop the rule once aqua-registry routes v1.27+ to `go_install`.

The checksum action also pushed `44ec9ce1` onto this branch, restoring the `anthropics/claude-code` v2.1.223 and `pnpm/pnpm` v11.20.0 entries that were missing from `aqua-checksums.json`. They went missing when #3010 was merged during the same outage with its checksum job dead, and nothing could repair them afterwards because delve was breaking every subsequent run. Since `require_checksum: true` is set, `aqua i` could not have succeeded locally in that state either.

## Notes for reviewers

- Renovate should close #3013 (delve v1.27.1) once this rule lands.
- **Why the red CI got auto-merged**: the "CI" ruleset has exactly one required status check, `status-check`. That job is guarded by `if: failure()`, so whenever it does not run its conclusion is `skipped` — and GitHub treats a `skipped` required check as satisfied. During the Actions outage on 2026-08-06 15:38-15:52 UTC (`Failed to resolve action download info. Error: Internal Server Error` / `Service Unavailable`) jobs died while resolving their actions, `status-check` was never scheduled, and auto-merge went through even though other jobs were red. All five runs in that window behave the same way. #3022 fixes the gate itself; it is out of scope here.
