### PR TITLE
ci: make status-check report a conclusion instead of skipping

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,15 @@ jobs:
       gh-app-private-key: ${{secrets.UPDATE_AQUA_CHECKSUM_APP_PRIVATE_KEY}}
     if: github.event_name == 'pull_request'
 
+  # NOTE:
+  # This is the only required status check of the "CI" ruleset, so it must
+  # never report `skipped` -- a skipped required check counts as satisfied.
+  # With `if: failure()` that conclusion was overloaded: it meant both "every
+  # dependency passed" and "GitHub never scheduled me". On 2026-08-06 an
+  # Actions outage made jobs die while resolving their actions, `failure()`
+  # did not fire, and #2783 and #3010 were auto-merged over a red CI.
+  # `always()` keeps the conclusion binary, and skipped dependencies stay
+  # acceptable so path- or event-filtered jobs can still opt out.
   status-check:
     runs-on: ubuntu-latest
     needs:
@@ -66,6 +75,7 @@ jobs:
       - format
       - update-aqua-checksums
     permissions: {}
-    if: failure()
+    if: ${{ always() }}
     steps:
-      - run: exit 1
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,14 +60,11 @@ jobs:
     if: github.event_name == 'pull_request'
 
   # NOTE:
-  # This is the only required status check of the "CI" ruleset, so it must
-  # never report `skipped` -- a skipped required check counts as satisfied.
-  # With `if: failure()` that conclusion was overloaded: it meant both "every
-  # dependency passed" and "GitHub never scheduled me". On 2026-08-06 an
-  # Actions outage made jobs die while resolving their actions, `failure()`
-  # did not fire, and #2783 and #3010 were auto-merged over a red CI.
-  # `always()` keeps the conclusion binary, and skipped dependencies stay
-  # acceptable so path- or event-filtered jobs can still opt out.
+  # The only required status check of the "CI" ruleset. GitHub counts a
+  # `skipped` required check as satisfied, so this job must run
+  # unconditionally: any path that leaves it unreached opens the gate.
+  # Skipped dependencies are deliberately not failures, so path- and
+  # event-filtered jobs can still opt out.
   status-check:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Why

`status-check` is the only required status check of the "CI" ruleset, and **GitHub treats a required check whose conclusion is `skipped` as satisfied**.

Under the current `if: failure()`, `skipped` is the conclusion whenever the job does not run. That overloads it to mean both:

- "every dependency passed" (intended), and
- "GitHub never scheduled me" (not intended)

The ruleset cannot tell those apart, so the second case silently opens the gate.

This is not hypothetical. During the GitHub Actions outage on 2026-08-06 15:38-15:52 UTC, jobs died while resolving their actions (`Failed to resolve action download info. Error: Service Unavailable` / `Internal Server Error`) and never reached their steps:

```
build                            failure
update-aqua-checksums / prepare  failure
update-aqua-checksums / update   skipped
format-lua / format-sh           success
status-check                     skipped   <- the required check
```

`build` failed, so `failure()` should have been true, yet `status-check` was `skipped` in all five runs in that window. The workflow definitions are byte-identical to the surrounding commits (verified by md5), so this is not a config difference — and in the ordinary case where a job fails during step execution (PR #3017) `failure()` fires correctly. GitHub does not document this behaviour, so the internal mechanism is not something I can assert, but it did not occur once outside the outage window.

The consequence was that **#2783 (delve v1.27.0, 15:43:53) and #3010 (claude-code v2.1.223, 15:46:05) were both auto-merged over a red CI**, which in turn:

- left delve breaking CI on every aqua PR (addressed in #3021)
- dropped the `claude-code` and `pnpm` entries from `aqua-checksums.json` on `main`, so with `require_checksum: true` even a local `aqua i` would fail (repaired by the automatic commit on #3021)

## What

Run `status-check` under `if: ${{ always() }}` and move the decision into a step guarded by `needs.*.result`. The conclusion is then always `success` or `failure`, which removes the ambiguity of `skipped`.

`skipped` dependencies are deliberately **not** treated as failures, so jobs that opt out via path or event filters keep working.

## Notes for reviewers

- This PR doubles as a live test. It touches no aqua files, so `update-aqua-checksums / update` is skipped — and `status-check` reports **success** instead of `skipped`. Confirmed on the current run.
- `actionlint` passes.
- No ruleset change is needed; the context name `status-check` is unchanged.
