### PR TITLE
feat(bin): link claude/codex config files individually

### DIFF
--- a/bin/deploy-config-files
+++ b/bin/deploy-config-files
@@ -56,12 +56,20 @@ ln_idempotently ./config/.config/tmux ~/.config/tmux
 ln_idempotently ./config/.config/herdr ~/.config/herdr
 
 # claude
-ln_idempotently ./config/.claude ~/.claude
+mkdir -p ~/.claude
 # ccgate.jsonnet imports this machine-local file; jsonnet errors when it is missing
 [ -f ./config/.claude/ccgate.local.libsonnet ] || echo '{}' >./config/.claude/ccgate.local.libsonnet
+ln_idempotently ./config/.claude/CLAUDE.md ~/.claude/CLAUDE.md
+ln_idempotently ./config/.claude/settings.json ~/.claude/settings.json
+ln_idempotently ./config/.claude/ccgate.jsonnet ~/.claude/ccgate.jsonnet
+ln_idempotently ./config/.claude/ccgate.local.libsonnet ~/.claude/ccgate.local.libsonnet
+ln_idempotently ./config/.claude/scripts ~/.claude/scripts
 
 # codex
-ln_idempotently ./config/.codex ~/.codex
+mkdir -p ~/.codex
+ln_idempotently --backup ./config/.codex/config.toml ~/.codex/config.toml
+ln_idempotently --backup ./config/.codex/AGENTS.md ~/.codex/AGENTS.md
+ln_idempotently --backup ./config/.codex/ccgate.jsonnet ~/.codex/ccgate.jsonnet
 
 # ruby
 ln_idempotently ./config/.config/irb ~/.config/irb


### PR DESCRIPTION
## Why

`deploy-config-files` symlinks the whole `~/.claude` / `~/.codex` directories to this repo, so Claude Code and Codex write all of their runtime state (sessions, history, plugins, caches, ...) into `config/.claude`, held back only by a `.gitignore` whitelist. On machines where Codex created a real `~/.codex` first, the whole-directory link has been failing anyway.

## What

- `~/.claude`: create a real directory and link only the tracked entries (`CLAUDE.md`, `settings.json`, `ccgate.jsonnet`, `scripts/`) plus the machine-local `ccgate.local.libsonnet` (seeded before linking, since `ln-idempotently` requires the target to exist)
- `~/.codex`: create a real directory and link `config.toml`, `AGENTS.md`, `ccgate.jsonnet` with `--backup`, since Codex may have created real files there first

## Notes for reviewers

- Existing machines need a one-time manual migration before this works: remove the legacy whole-directory symlink, create a real directory, and move the runtime files out of `config/.claude`. Until then, each individual link fails with a warning (non-fatal since #3067), which is the signal to migrate.
- `.gitignore` is intentionally unchanged: `scripts/tmp` and `ccgate.local.libsonnet` still live in the repo and need to stay ignored.
- `~/.codex/config.toml` is rewritten by Codex at runtime (trusted projects etc.), so once linked, those writes will show up as an uncommitted diff on `config/.codex/config.toml`. Machine-local content there should not be committed to this public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)