### PR TITLE
feat(bin): exit 0 on link failures without --fail-fast

### DIFF
--- a/bin/deploy-config-files
+++ b/bin/deploy-config-files
@@ -120,5 +120,4 @@ ln_idempotently ./config/.config/any-script-mcp ~/.config/any-script-mcp
 if [ "${#failed[@]}" -gt 0 ]; then
   echo "Warning: ${#failed[@]} link(s) failed:" >&2
   printf '  %s\n' "${failed[@]}" >&2
-  exit 1
 fi


### PR DESCRIPTION
## Why

Without `--fail-fast`, `deploy-config-files` is meant to be best-effort: it already continues past link failures and reports them at the end (#3067). Exiting with 1 in that mode made callers (e.g. setup scripts, CI) treat a partially successful deploy as a hard failure.

## What

- Drop the final `exit 1` when links fail in non-`--fail-fast` mode; the warning summary on stderr is still printed
- `--fail-fast` behavior is unchanged: it still exits 1 on the first failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)