### PR TITLE
feat(agents): add code-comments skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,7 @@ dist
 
 # ignore installed by `skills`
 /config/.agents/skills/*
+!/config/.agents/skills/code-comments
 
 # lazysql
 /config/.config/lazysql/history

--- a/bin/deploy-config-files
+++ b/bin/deploy-config-files
@@ -67,6 +67,8 @@ ln_idempotently ./config/.claude/settings.json ~/.claude/settings.json
 ln_idempotently ./config/.claude/ccgate.jsonnet ~/.claude/ccgate.jsonnet
 ln_idempotently ./config/.claude/ccgate.local.libsonnet ~/.claude/ccgate.local.libsonnet
 ln_idempotently ./config/.claude/scripts ~/.claude/scripts
+mkdir -p ~/.claude/skills
+ln_idempotently ./config/.agents/skills/code-comments ~/.claude/skills/code-comments
 
 # codex
 mkdir -p ~/.codex

--- a/config/.agents/skills/code-comments/SKILL.md
+++ b/config/.agents/skills/code-comments/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: code-comments
+description: Rules for writing and editing code comments — inline comments, doc comments (TSDoc, GoDoc, docstrings), and TODOs. Use when writing or changing code, adding or editing comments, or reviewing a diff for comment quality.
+---
+
+# Code Comments
+
+A comment earns its place only by saying something true about the code as it stands now that the code itself cannot say: the why behind a decision, a rejected alternative (why not), an invariant, or a non-obvious constraint. Every other comment costs more than it gives — readers must process it, and maintainers must keep it true.
+
+These rules apply to the code you are writing or changing. Leave the rest alone: don't add comments, docstrings, or type annotations to code you didn't touch.
+
+## Present-tense why only
+
+Describe the code as it is, never how it got that way. Change history, migration notes, "the old approach", "previously", "changed from X to Y" — that story belongs in the commit message and PR, where it stays attached to its moment. In code it reads as noise today and becomes misleading once the context is gone.
+
+```ts
+// Bad: narrates the change
+// Previously resolved via apiKeyHelper, but that was rejected due to
+// startup latency, so we now read the env var directly.
+const apiKey = process.env.API_KEY;
+
+// Good: states the present-tense reason
+// An exec-per-request helper adds ~200ms startup latency; the env var is enough.
+const apiKey = process.env.API_KEY;
+```
+
+The same applies to leftovers: when something is removed or deprecated, the comments about it go with it.
+
+## Nothing self-evident
+
+If the code already says it, a comment repeating it is pure cost. When you feel a comment is needed to explain *what* the code does, first try making the code obvious instead — a plain implementation with no comment beats a clever one with an explanation.
+
+```ts
+// Bad: restates the code
+// Generate an 8-byte random hex string
+const id = crypto.randomBytes(8).toString("hex");
+
+// Good: no comment — the code is the explanation
+const id = crypto.randomBytes(8).toString("hex");
+```
+
+## Concise, but complete
+
+Long, meandering comments bury their point. Write the shortest comment that still carries every premise the reader needs — trim the prose, not the reasoning.
+
+## Anchor doc comments to a symbol
+
+Free-floating commentary at the top of a file has no owner and rots fastest. Attach documentation to the thing it documents as a doc comment (TSDoc, GoDoc, docstring). Language-conventional file docs (Go package docs, module docstrings) are fine.
+
+## References must stand alone
+
+A bare pointer like `(§5.3.4)` or a ticket ID is meaningless without the referenced document, and those documents are transient. Write the actual reasoning into the comment; a full URL may back it up, never replace it.
+
+```ts
+// Bad: meaningless without the doc
+// See §5.3.4
+if (attempt > MAX_RETRIES) throw new FatalError("giving up");
+
+// Good: the reason is in the comment; the link is a bonus
+// The queue redelivers up to 3 times; a 4th failure means the payload
+// itself is bad, so retrying cannot help.
+// https://docs.example.com/queue/redelivery
+if (attempt > MAX_RETRIES) throw new FatalError("giving up");
+```
+
+## Fix stale comments in code you touch
+
+When your change makes a nearby comment wrong — or you find one referencing something that no longer exists — updating or deleting it is part of the change, not an optional cleanup.
+
+## Before you finish
+
+Reread the comments in your diff once: anything narrating the change, restating the code, or padding the point gets deleted.

--- a/config/.claude/CLAUDE.md
+++ b/config/.claude/CLAUDE.md
@@ -48,8 +48,8 @@ Think in English, interact with the user in Japanese.
   - Do not add a `Test plan` section
 
 ### Comments
-- Document **Why** (intent and reasoning)
-- Skip self-evident **What** comments. Exception: multi-line complex processing or intricate control flow
+- Comments state the **present-tense Why / Why-not** of the code — never change history, migration notes, or anything self-evident
+- Read the `code-comments` skill before writing or editing code comments
 
 ### JavaScript / TypeScript
 - Run via the project's `packageManager`

--- a/config/.codex/AGENTS.md
+++ b/config/.codex/AGENTS.md
@@ -65,9 +65,8 @@
 
 ## Comment Rules
 
-- Write comments for why, invariants, and tradeoffs
-- Avoid comments that restate obvious code behavior
-- Add concise notes only where future maintainers would otherwise guess intent
+- Comments state the present-tense why / why-not of the code — never change history, migration notes, or anything self-evident
+- Read `~/.agents/skills/code-comments/SKILL.md` before writing or editing code comments, and follow it
 
 ---
 


### PR DESCRIPTION
## Why

Session transcripts from 2026-07 through 2026-09 contain 12+ recurring corrections about how coding agents write code comments — most frequently narrating change history / migration context in comments, followed by self-evident restatements, bare section-number references, and stale comments left behind. The existing 3-line Comments sections in CLAUDE.md / AGENTS.md did not capture most of these failure modes (notably, "document Why" was being read as "document the Why of the *change*", producing exactly the history comments being corrected), so each one had to be re-explained per session.

## What

- Add `config/.agents/skills/code-comments/SKILL.md`: distills the recurring feedback into 6 rules (present-tense why only / nothing self-evident / concise but complete / doc comments anchored to symbols / standalone references / fix stale comments in touched code), written per the Opus 5 prompting guide — rationale attached to each rule, bad/good example pairs, no emphatic directives, explicit scope limited to code being changed
- Whitelist the skill in `.gitignore` (the rest of `config/.agents/skills/` remains vendor output of the `skills` CLI) and link it from `bin/deploy-config-files` into `~/.claude/skills`
- Replace the Comments sections in `config/.claude/CLAUDE.md` and `config/.codex/AGENTS.md` with a one-line core rule plus a pointer to the skill (Claude via the skill mechanism, Codex via the `~/.agents` file path, since Codex has no skill auto-loading)

## Notes for reviewers

- First hand-authored skill in this repo; everything else under `config/.agents/skills/` is installed by the `skills` CLI. The `.gitignore` negation pattern mirrors the existing `config/.claude/*` whitelist style.
- `config/.claude/CLAUDE.md` had an unrelated uncommitted edit on this machine (history-rewriting rules); only the Comments hunk is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtH5FSdLgjhi44Z4yNGPWu